### PR TITLE
Fix grammar error on ant_p2p_setup.sh and update .gitignore of bluez-4.101

### DIFF
--- a/scripts/install/ant_p2p_setup.sh
+++ b/scripts/install/ant_p2p_setup.sh
@@ -19,7 +19,7 @@ init_wf()
 
 	IS_INIT=`cat ${INIT_PATH}/self | awk '{print $1}'`
 	echo $IS_INIT
-	if [ -z ${IS_INIT} -o ${IS_INIT} -eq '1' ] 
+	if [ "${IS_INIT}" = "1" ];
 	then
 		exit 1
 	fi


### PR DESCRIPTION
* Fix grammar error on ```ant_p2p_setup.sh```
* Update ```.gitignore``` of bluez-4.101. When building bluez-4.101, ```lexer.c```, ```parser.c``` and  ```parser.h``` are also changed.