### PR TITLE
Runtime dynamic library linking bug fix

### DIFF
--- a/scripts/install/run_ant.tail
+++ b/scripts/install/run_ant.tail
@@ -6,7 +6,7 @@ ANT_PYTHON3_PATH=`which python3`
 source ${ANT_CONFIG_DIR}/profile.env
 
 # set shared library path
-export LD_LIBRARY_PATH="${ANT_BIN_DIR}/libs:${LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="{ANT_SENSOR_DRIVER_DIR}:${ANT_BIN_DIR}/libs:/usr/lib:/usr/local/lib:${LD_LIBRARY_PATH}"
 
 if [[ $# -eq 1 ]]; then
   ${ANT_PYTHON3_PATH} ${ANT_BIN_DIR}/ant.py $1

--- a/target/raspberry-pi2_3/install-deps-raspberry-pi2_3.sh
+++ b/target/raspberry-pi2_3/install-deps-raspberry-pi2_3.sh
@@ -124,7 +124,10 @@ sudo make install
 
 # Step 13. Install FANN Library
 cd ${ANT_REPO_DIR}/dep/fann
-cmake .
+mkdir build
+cd build
+cmake ..
+make -j4
 sudo make install
 
 WARN_COLO="\033[31;47m"


### PR DESCRIPTION


## Bug fix - Dynamic library linking at runtime
We are using several shared library which should be linked at runtime.
I updated the linking path.
refer to "scripts/install/run_ant.tail"

## Install-deps.sh - Fann library
There was some omitted process in installing fann library.
I updated the install-deps.sh script 
