### PR TITLE
Resolve parallel build dependency issue on CMakeList.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ cd ${ANT_ROOT_DIR}
 $ mkdir build
 $ cd build
 $ cmake ..
-$ make   ## Please do not give -j option
+$ make -j4
 ```
 
 ### How to Install

--- a/framework/appcore/CMakeLists.txt
+++ b/framework/appcore/CMakeLists.txt
@@ -25,6 +25,7 @@ set(ACM_sources
   ${ACM_SOURCE_DIR}/AppList.cpp)
 
 add_executable(ant-appcore ${ACM_sources} $<TARGET_OBJECTS:miniunz>)
+add_dependencies(ant-appcore ant-message)
 
 target_link_libraries(ant-appcore
   ant-message ant-cmfw

--- a/framework/machine-learning/CMakeLists.txt
+++ b/framework/machine-learning/CMakeLists.txt
@@ -20,6 +20,7 @@ set(MLFW_sources
   ${MLFW_SOURCE_DIR}/ANNInferenceRunner.cpp)
 
 add_executable(ant-ml ${MLFW_sources})
+add_dependencies(ant-ml ant-message)
 
 target_link_libraries(ant-ml
   ant-message ant-cmfw pthread fann doublefann fixedfann floatfann)

--- a/framework/message/CMakeLists.txt
+++ b/framework/message/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MESSAGE_sources
   ${MESSAGE_SOURCE_DIR}/cJSON.c)
 
 add_library(ant-message SHARED ${MESSAGE_sources})
+add_dependencies(ant-message ant-cmfw)
 
 target_link_libraries(ant-message
   ant-cmfw

--- a/new-api/CMakeLists.txt
+++ b/new-api/CMakeLists.txt
@@ -8,3 +8,4 @@ add_custom_target(
   COMMENT "Building New ANT API"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
+add_dependencies(new-api ant-message)


### PR DESCRIPTION
Now, we can use ```make -j4```!
* Resolve parallel build dependency issue on CMakeList.txt (Issue #32)