### PR TITLE
MLFW can send label to CAMFW

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -209,4 +209,23 @@ limitations under the License.
     This license applies to parts of '*.py' files in '/tools/common_py', 
     implementing python-based travis script, originating from the 
     https://github.com/Samsung/iotjs repository;
+  
+ 
+    _____________________
 
+    COPYRIGHT
+  
+    All contributions by the University of California:
+    Copyright (c) 2014-2017 The Regents of the University of California (Regents)
+    All rights reserved.
+  
+    All other contributions:
+    Copyright (c) 2014-2017, the respective contributors
+    All rights reserved.
+  
+    Caffe uses a shared copyright model: each contributor holds copyright over
+    their contributions to Caffe. The project versioning records all such
+    contribution and copyright details. If a contributor wants to further mark
+    their specific copyright on a particular contribution, they should indicate
+    their copyright solely in the commit message of the change when it is
+    committed.

--- a/framework/camera/inc/CameraCommunicator.h
+++ b/framework/camera/inc/CameraCommunicator.h
@@ -52,9 +52,13 @@ class CameraCommunicator {
         CameraController *controller, CameraConfigParser *config_parser);
     DBusHandlerResult copyShmStop(DBusMessage *msg,
         CameraController *controller, CameraConfigParser *config_parser);
-    DBusHandlerResult sensorOverlayStart(DBusMessage *msg,
+    DBusHandlerResult textOverlayStart(DBusMessage *msg,
         CameraController *controller, CameraConfigParser *config_parser);
-    DBusHandlerResult sensorOverlayStop(DBusMessage *msg,
+    DBusHandlerResult textOverlayStop(DBusMessage *msg,
+        CameraController *controller, CameraConfigParser *config_parser);
+    DBusHandlerResult showWindowStart(DBusMessage *msg,
+        CameraController *controller, CameraConfigParser *config_parser);
+    DBusHandlerResult showWindowStop(DBusMessage *msg,
         CameraController *controller, CameraConfigParser *config_parser);
 
   private:

--- a/framework/camera/inc/CameraConfigParser.h
+++ b/framework/camera/inc/CameraConfigParser.h
@@ -35,9 +35,8 @@ class CameraConfigParser {
     GstElement* getStreamingBin();
     GstElement* getPreRecordingInitBin();
     GstElement* getPreRecordingBin();
-    
     GstElement* getCopyShmBin();
-    GstElement* getFaceDetectBin();
+    GstElement* getShowWindowBin();
 
   public:
     cJSON *mCameraConfigCjson;
@@ -46,9 +45,8 @@ class CameraConfigParser {
     char *mStreamingConfig;
     char *mPreRecordingInitConfig;
     char *mPreRecordingConfig;
-    
     char *mCopyShmConfig;
-    char *mFaceDetectConfig;
+    char *mShowWindowConfig;
 };
 
 #endif /* CAMERA_CONFIG_PARSER_H */

--- a/framework/camera/inc/CameraDevice.h
+++ b/framework/camera/inc/CameraDevice.h
@@ -43,8 +43,10 @@ class CameraDevice {
     bool preRecordingStop(CameraRequest *request);
     bool copyShmStart(CameraRequest *request);
     bool copyShmStop(CameraRequest *request);
-    bool sensorOverlayStart(CameraRequest *request);
-    bool sensorOverlayStop(CameraRequest *request);
+    bool textOverlayStart(CameraRequest *request);
+    bool textOverlayStop(CameraRequest *request);
+    bool showWindowStart(CameraRequest *request);
+    bool showWindowStop(CameraRequest *request);
 
     GstElement* getPipeline()
     { return this->mPipeline; }
@@ -61,6 +63,8 @@ class CameraDevice {
     { return this->mDelayedValve; }
     GstElement* getCopyShmValve()
     { return this->mCopyShmValve; }
+    GstElement* getTextOverlay()
+    { return this->mTextOverlay; }
 
     unsigned getCopyShmNumUsers()
     { return this->copy_shm_num_users; }

--- a/framework/camera/inc/CameraRequest.h
+++ b/framework/camera/inc/CameraRequest.h
@@ -33,8 +33,10 @@ typedef enum _RequestType {
   kPreRecordingStop,
   kCopyShmStart,
   kCopyShmStop,
-  kSensorOverlayStart,
-  kSensorOverlayStop,
+  kTextOverlayStart,
+  kTextOverlayStop,
+  kShowWindowStart,
+  kShowWindowStop,
 } RequestType;
 
 class CameraRequest {
@@ -116,10 +118,10 @@ typedef struct _dbusStreamingRequest {
   unsigned port;
 } dbusStreamingRequest;
 
-typedef struct _dbusSensorRequest {
+typedef struct _dbusTextRequest {
   unsigned pid;
   unsigned camera_id;
-  const char *sensor_name;
-} dbusSensorRequest;
+  const char *text_content;
+} dbusTextRequest;
 
 #endif /* CAMERA_REQUEST_H */

--- a/framework/camera/src/CameraCommunicator.cpp
+++ b/framework/camera/src/CameraCommunicator.cpp
@@ -424,64 +424,125 @@ DBusHandlerResult CameraCommunicator::copyShmStop(DBusMessage *msg,
   return DBUS_HANDLER_RESULT_HANDLED;
 }
 
-DBusHandlerResult CameraCommunicator::sensorOverlayStart(DBusMessage *msg,
+DBusHandlerResult CameraCommunicator::textOverlayStart(DBusMessage *msg,
     CameraController *controller, CameraConfigParser *config_parser)
 {
-  ANT_LOG_DBG(CAM, "Get sensor start request");
+  ANT_LOG_DBG(CAM, "Get text overlay start request");
   bool ret;
 
-  dbusSensorRequest *msg_handle = (dbusSensorRequest*)malloc(sizeof(dbusSensorRequest));
+  dbusTextRequest *msg_handle = (dbusTextRequest*)malloc(sizeof(dbusTextRequest));
 
   dbus_message_get_args(msg, NULL,
       DBUS_TYPE_UINT64, &(msg_handle->pid),
       DBUS_TYPE_UINT64, &(msg_handle->camera_id),
-      DBUS_TYPE_STRING, &(msg_handle->sensor_name),
+      DBUS_TYPE_STRING, &(msg_handle->text_content),
       DBUS_TYPE_INVALID);
 
   ANT_LOG_DBG(CAM, "PID : %u", msg_handle->pid);
   ANT_LOG_DBG(CAM, "Camera ID : %u", msg_handle->camera_id);
-  ANT_LOG_DBG(CAM, "Sensor Name : %s", msg_handle->sensor_name);
+  ANT_LOG_DBG(CAM, "Text Content : %s", msg_handle->text_content);
 
-  CameraRequest *request = new CameraRequest(kSensorOverlayStart);
+  CameraRequest *request = new CameraRequest(kTextOverlayStart);
   request->setMsgHandle(msg_handle);
 
   CameraDevice *device = controller->getDeviceById(msg_handle->camera_id);
   request->setCameraDevice(device);
   ret = device->processRequest(request);
   if (!ret) {
-    ANT_LOG_ERR(CAM, "Sensor overlay start failed");
+    ANT_LOG_ERR(CAM, "Text overlay start failed");
     return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
   }
 
   return DBUS_HANDLER_RESULT_HANDLED;
 }
 
-DBusHandlerResult CameraCommunicator::sensorOverlayStop(DBusMessage *msg,
+DBusHandlerResult CameraCommunicator::textOverlayStop(DBusMessage *msg,
     CameraController *controller, CameraConfigParser *config_parser)
 {
-  ANT_LOG_DBG(CAM, "Get sensor stop request");
+  ANT_LOG_DBG(CAM, "Get text overlay stop request");
   bool ret;
 
-  dbusSensorRequest *msg_handle = (dbusSensorRequest*)malloc(sizeof(dbusSensorRequest));
+  dbusTextRequest *msg_handle = (dbusTextRequest*)malloc(sizeof(dbusTextRequest));
 
   dbus_message_get_args(msg, NULL,
       DBUS_TYPE_UINT64, &(msg_handle->pid),
       DBUS_TYPE_UINT64, &(msg_handle->camera_id),
-      DBUS_TYPE_STRING, &(msg_handle->sensor_name),
+      DBUS_TYPE_STRING, &(msg_handle->text_content),
       DBUS_TYPE_INVALID);
 
   ANT_LOG_DBG(CAM, "PID : %u", msg_handle->pid);
   ANT_LOG_DBG(CAM, "Camera ID : %u", msg_handle->camera_id);
-  ANT_LOG_DBG(CAM, "Sensor Name : %s", msg_handle->sensor_name);
+  ANT_LOG_DBG(CAM, "Text Content : %s", msg_handle->text_content);
 
-  CameraRequest *request = new CameraRequest(kSensorOverlayStop);
+  CameraRequest *request = new CameraRequest(kTextOverlayStop);
   request->setMsgHandle(msg_handle);
 
   CameraDevice *device = controller->getDeviceById(msg_handle->camera_id);
   request->setCameraDevice(device);
   ret = device->processRequest(request);
   if (!ret) {
-    ANT_LOG_ERR(CAM, "Sensor overlay start failed");
+    ANT_LOG_ERR(CAM, "Text overlay start failed");
+    return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+  }
+
+  return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+DBusHandlerResult CameraCommunicator::showWindowStart(DBusMessage *msg,
+    CameraController *controller, CameraConfigParser *config_parser)
+{
+  ANT_LOG_DBG(CAM, "Get show window start request");
+  bool ret;
+
+  dbusRequest *msg_handle = (dbusRequest*)malloc(sizeof(dbusRequest));
+
+  dbus_message_get_args(msg, NULL,
+      DBUS_TYPE_UINT64, &(msg_handle->pid),
+      DBUS_TYPE_UINT64, &(msg_handle->camera_id),
+      DBUS_TYPE_INVALID);
+
+  ANT_LOG_DBG(CAM, "PID : %u", msg_handle->pid);
+  ANT_LOG_DBG(CAM, "Camera ID : %u", msg_handle->camera_id);
+
+  GstElement *show_window_bin = config_parser->getShowWindowBin();
+  CameraRequest *request = new CameraRequest(kShowWindowStart, show_window_bin);
+  request->setMsgHandle(msg_handle);
+
+  CameraDevice *device = controller->getDeviceById(msg_handle->camera_id);
+  request->setCameraDevice(device);
+  ret = device->processRequest(request);
+  if (!ret) {
+    ANT_LOG_ERR(CAM, "Show window start failed");
+    return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+  }
+
+  return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+DBusHandlerResult CameraCommunicator::showWindowStop(DBusMessage *msg,
+    CameraController *controller, CameraConfigParser *config_parser)
+{
+  ANT_LOG_DBG(CAM, "Get show window stop request");
+  bool ret;
+
+  dbusRequest *msg_handle = (dbusRequest*)malloc(sizeof(dbusRequest));
+
+  dbus_message_get_args(msg, NULL,
+      DBUS_TYPE_UINT64, &(msg_handle->pid),
+      DBUS_TYPE_UINT64, &(msg_handle->camera_id),
+      DBUS_TYPE_INVALID);
+
+  ANT_LOG_DBG(CAM, "PID : %u", msg_handle->pid);
+  ANT_LOG_DBG(CAM, "Camera ID : %u", msg_handle->camera_id);
+
+  CameraRequest *request = new CameraRequest(kShowWindowStop);
+  request->setMsgHandle(msg_handle);
+
+  CameraDevice *device = controller->getDeviceById(msg_handle->camera_id);
+  request->setCameraDevice(device);
+  ret = device->processRequest(request);
+  if (!ret) {
+    ANT_LOG_ERR(CAM, "Show window start failed");
     return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
   }
 

--- a/framework/camera/src/CameraConfigParser.cpp
+++ b/framework/camera/src/CameraConfigParser.cpp
@@ -71,6 +71,7 @@ int CameraConfigParser::readyCameraConfig()
   this->mPreRecordingInitConfig = cJSON_GetObjectItem(root, "pre_recording_init")->valuestring;
   this->mPreRecordingConfig = cJSON_GetObjectItem(root, "pre_recording")->valuestring;
   this->mCopyShmConfig = cJSON_GetObjectItem(root, "copy_shm")->valuestring;
+  this->mShowWindowConfig = cJSON_GetObjectItem(root, "show_window")->valuestring;
 
   ANT_LOG_DBG(CAM, "Number of camera = %d", camera_num);
   ANT_LOG_DBG(CAM, "Recording = %s", this->mRecordingConfig);
@@ -79,6 +80,7 @@ int CameraConfigParser::readyCameraConfig()
   ANT_LOG_DBG(CAM, "Pre-Recording Init = %s", this->mPreRecordingInitConfig);
   ANT_LOG_DBG(CAM, "Pre-Recording = %s", this->mPreRecordingConfig);
   ANT_LOG_DBG(CAM, "CopyShm = %s", this->mCopyShmConfig);
+  ANT_LOG_DBG(CAM, "Show window = %s", this->mShowWindowConfig);
 
   return camera_num;
 }
@@ -122,4 +124,9 @@ GstElement* CameraConfigParser::getPreRecordingBin()
 GstElement* CameraConfigParser::getCopyShmBin()
 {
   return gst_parse_bin_from_description(this->mCopyShmConfig, TRUE, NULL);
+}
+
+GstElement* CameraConfigParser::getShowWindowBin()
+{
+  return gst_parse_bin_from_description(this->mShowWindowConfig, TRUE, NULL);
 }

--- a/framework/camera/src/CameraManager.cpp
+++ b/framework/camera/src/CameraManager.cpp
@@ -199,10 +199,14 @@ DBusHandlerResult msg_dbus_filter(DBusConnection *connection,
     return communicator->copyShmStart(msg, controller, config_parser);
   else if (dbus_message_is_signal(msg, "org.ant.cameraManager", "copyShmStop"))
     return communicator->copyShmStop(msg, controller, config_parser);
-  else if (dbus_message_is_signal(msg, "org.ant.cameraManager", "sensorOverlayStart"))
-    return communicator->sensorOverlayStart(msg, controller, config_parser);
-  else if (dbus_message_is_signal(msg, "org.ant.cameraManager", "sensorOverlayStop"))
-    return communicator->sensorOverlayStop(msg, controller, config_parser);
+  else if (dbus_message_is_signal(msg, "org.ant.cameraManager", "textOverlayStart"))
+    return communicator->textOverlayStart(msg, controller, config_parser);
+  else if (dbus_message_is_signal(msg, "org.ant.cameraManager", "textOverlayStop"))
+    return communicator->textOverlayStop(msg, controller, config_parser);
+  else if (dbus_message_is_signal(msg, "org.ant.cameraManager", "showWindowStart"))
+    return communicator->showWindowStart(msg, controller, config_parser);
+  else if (dbus_message_is_signal(msg, "org.ant.cameraManager", "showWindowStop"))
+    return communicator->showWindowStop(msg, controller, config_parser);
 
   ANT_LOG_WARN(CAM, "Receive unidentified D-bus message");
   return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;

--- a/framework/machine-learning/inc/DNNInferenceRunner.h
+++ b/framework/machine-learning/inc/DNNInferenceRunner.h
@@ -104,6 +104,6 @@ class DNNInferenceRunner
 static bool pairCompare(const std::pair<float, int>& lhs,
                         const std::pair<float, int>& rhs);
 static std::vector<int> argmax(const std::vector<float>& v, int N);
-static void sendDBusMsg(DBusConnection* conn, const char* msg);
+static void sendDBusMsg(DBusConnection* conn, const char* msg, const char* text);
 
 #endif // !defined(__DNN_INFERENCE_RUNNER_H__)

--- a/target/raspberry-pi2_3/camera-config.json
+++ b/target/raspberry-pi2_3/camera-config.json
@@ -2,12 +2,14 @@
   "target": "raspberry-pi2_3",
   "camera_num":1,
   "main": {
-    "0": "rpicamsrc preview=f ! video/x-raw,width=1280,height=720,framerate=30/1,format=I420 ! tee name=RAW_TEE ! queue ! tee name=MAIN_TEE ! queue ! omxh264enc ! tee name=H264_TEE ! queue ! fakesink"
+    "0": "rpicamsrc preview=f ! video/x-raw,width=1280,height=720,framerate=30/1,format=RGB ! tee name=RAW_TEE ! queue ! tee name=MAIN_TEE ! queue ! opencvtextoverlay text=\"\" name=TEXT ypos=100 height=3 width=3 thickness=10 ! videoconvert ! omxh264enc ! tee name=H264_TEE ! queue ! fakesink",
+    "0_test": "rpicamsrc preview=f ! video/x-raw,width=1280,height=720,framerate=30/1,format=RGB ! tee name=RAW_TEE ! queue ! tee name=MAIN_TEE ! queue ! opencvtextoverlay text=\"\" name=TEXT ypos=100 height=3 width=3 thickness=10 ! videoconvert ! omxh264enc ! tee name=H264_TEE ! queue ! h264parse ! rtph264pay config-interval=1 pt=96 ! udpsink host=192.168.0.35 port=4000 name=sink_%u sync=f"
   },
   "recording": "queue ! h264parse ! mp4mux ! filesink name=sink_%u sync=f",
   "snapshot": "queue ! jpegenc ! image/jpeg,width=1280,height=720,framerate=1/1 ! appsink name=sink_%u",
   "streaming": "queue ! h264parse ! rtph264pay pt=96 config-interval=1 ! gdppay ! tcpserversink name=sink_%u sync=f",
   "pre_recording_init": "queue min-threshold-time=10000000000 max-size-buffers=0 max-size-time=0 max-size-bytes=0 ! valve drop=true ! tee name=sink_%u",
   "pre_recording": "queue ! h264parse ! mp4mux ! filesink name=sink_%u sync=f",
-  "copy_shm": "queue ! videorate ! video/x-raw,framerate=1/1 ! videoscale ! video/x-raw,width=640,height=480 ! videoconvert ! video/x-raw,format=BGR ! appsink name=sink_%u"
+  "copy_shm": "queue ! videorate ! video/x-raw,framerate=1/1 ! videoscale ! video/x-raw,width=640,height=480 ! videoconvert ! video/x-raw,format=BGR ! appsink name=sink_%u",
+  "show_window": "queue ! videorate ! video/x-raw,framerate=10/1 ! videoscale ! video/x-raw,width=640,height=480 ! autovideosink name=sink_%u"
 }

--- a/test/cpp/camera-client/ANTdbusInterface.cpp
+++ b/test/cpp/camera-client/ANTdbusInterface.cpp
@@ -61,7 +61,7 @@ static void send_delay_streaming_start(DBusConnection *conn)
   dbus_message_unref(message);
 }
 
-static void send_sensor_overlay(DBusConnection *conn)
+static void send_text_overlay(DBusConnection *conn)
 {
   printf("Sensor overlay start\n");
   DBusMessage *message;
@@ -83,7 +83,7 @@ static void send_sensor_overlay(DBusConnection *conn)
   dbus_message_unref(message);
 }
 
-static void send_sensor_overlay_stop(DBusConnection *conn)
+static void send_text_overlay_stop(DBusConnection *conn)
 {
   printf("Sensor overlay stop\n");
   DBusMessage *message;
@@ -105,7 +105,7 @@ static void send_sensor_overlay_stop(DBusConnection *conn)
   dbus_message_unref(message);
 }
 
-static void send_rec_init(DBusConnection *conn, char* file_name)
+static void send_rec_start(DBusConnection *conn, char* file_name)
 {
   printf("Recording Start\n");
   DBusMessage *message;
@@ -140,7 +140,7 @@ static void send_rec_init(DBusConnection *conn, char* file_name)
   dbus_message_unref(message);
 }
 
-static void send_rec_start(DBusConnection *conn, char* file_name)
+static void send_snapshot_start(DBusConnection *conn, char* file_name)
 {
   printf("start\n");
   DBusMessage *message;
@@ -174,9 +174,9 @@ static void send_rec_start(DBusConnection *conn, char* file_name)
   dbus_message_unref(message);
 }
 
-static void send_rec_term(DBusConnection *conn)
+static void send_copy_shm_start(DBusConnection *conn)
 {
-  printf("termination\n");
+  printf("Copy Shared Memory Start\n");
   DBusMessage *message;
   message = dbus_message_new_signal(dbus_path, dbus_interface, copy_shm_start_request);
 
@@ -220,7 +220,7 @@ static void send_stream_start(DBusConnection *conn)
 
 static void send_stream_stop(DBusConnection *conn)
 {
-	printf("streaming stop");
+	printf("streaming stop\n");
 	DBusMessage *message;
 	message = dbus_message_new_signal(dbus_path, dbus_interface, streaming_stop_request);
 	dbus_connection_send(conn, message, NULL);
@@ -228,9 +228,29 @@ static void send_stream_stop(DBusConnection *conn)
 
 }
 
+static void send_show_window_start(DBusConnection *conn)
+{
+	printf("show window start\n");
+	DBusMessage *message;
+	message = dbus_message_new_signal(dbus_path, dbus_interface, "showWindowStart");
+
+  unsigned pid = getpid();
+  unsigned camera_num = 0;
+  printf("Camera Number : ");
+  scanf("%d", &camera_num);
+
+	dbus_message_append_args(message,
+      DBUS_TYPE_UINT64, &pid,
+      DBUS_TYPE_UINT64, &camera_num,
+			DBUS_TYPE_INVALID);
+	
+	dbus_connection_send(conn, message, NULL);
+	dbus_message_unref(message);
+}
+
 int main(int argc, char** argv)
 {
- int num;
+ RequestType num;
  DBusConnection *conn;
  DBusError error;
  dbus_error_init (&error);
@@ -249,24 +269,26 @@ int main(int argc, char** argv)
  for(;;)
  {
 	 scanf("%d", &num); 
-   if(num == 0)
-	 	send_rec_init(conn, argv[1]); 
-	 else if(num == 1) 
-		send_rec_start(conn, argv[1]);	 
-	 else if(num == 2)
-		send_rec_term(conn);
-	 else if(num == 3)
+   if(num == kRecordingStart)
+	 	send_rec_start(conn, argv[1]); 
+	 else if(num == kSnapshot) 
+		send_snapshot_start(conn, argv[1]);	 
+	 else if(num == kCopyShmStart)
+		send_copy_shm_start(conn);
+	 else if(num == kStreamingStart)
 		 send_stream_start(conn);
-	 else if(num == 4)
+	 else if(num == kStreamingStop)
 		 send_stream_stop(conn);
-   else if(num == 5)
-     send_sensor_overlay(conn);
-	 else if(num == 6)
-		 send_sensor_overlay_stop(conn);
-	 else if(num == 7)
+   else if(num == kTextOverlayStart)
+     send_text_overlay(conn);
+	 else if(num == kTextOverlayStop)
+		 send_text_overlay_stop(conn);
+	 else if(num == kPreRecordingInit)
 		 send_delay_streaming_start(conn);
-	 else if(num == 8)
+	 else if(num == kPreRecordingStart)
 		 send_event_rec_start(conn, argv[1]);
+   else if(num == kShowWindowStop)
+     send_show_window_start(conn);
 	 else
 		 break;
  }

--- a/test/cpp/camera-client/ANTdbusInterface.h
+++ b/test/cpp/camera-client/ANTdbusInterface.h
@@ -26,6 +26,22 @@ static const gchar *delay_streaming_stop_request = "delayStreamingStop";
 static const gchar *event_rec_start_request = "eventRecStart";
 static const gchar *event_rec_stop_request = "eventRecStop";
 
+typedef enum _RequestType {
+  kRecordingStart,
+  kRecordingStop,
+  kSnapshot,
+  kStreamingStart,
+  kStreamingStop,
+  kPreRecordingInit,
+  kPreRecordingStart,
+  kPreRecordingStop,
+  kCopyShmStart,
+  kCopyShmStop,
+  kTextOverlayStart,
+  kTextOverlayStop,
+  kShowWindowStart,
+  kShowWindowStop,
+} RequestType;
 
 typedef struct _dbusReques{
   unsigned camera_num;


### PR DESCRIPTION
## Changes
- MLFW can send label to CAMFW using D-BUS
- CAMFW shows classifying result using text overlay
- I add two feature for TEST
  1. In ```camera-config.json```, if you use "0_test" pipeline, then you will check output through other devices.
  2. show_window: show output on device's own screen (work in progress)