### PR TITLE
Add start/stop app button to app editor

### DIFF
--- a/lite/app-runtime/app-editor/index.html
+++ b/lite/app-runtime/app-editor/index.html
@@ -133,6 +133,18 @@
       });
     }
 
+    function onStopAppButton() {
+      console.log("onStopAppButton");
+      var url = "http://" + getTargetUrl() + "/runtime/currentApp/command";
+      sendHTTPRequest(url, "POST", "stop", function (responseCode, responseText) {
+        if (responseCode == 200) {
+          changeStatusLabel("Stop app success");
+        } else {
+          changeStatusLabel("Stop app failed: " + responseText);
+        }
+      });
+    }
+
     function onReloadCodeButton() {
       console.log("onReloadCodeButton");
       loadTargetAppCode(function (responseCode, responseText) {
@@ -172,6 +184,7 @@ ant.runtime.setCurrentApp(on_initialize, on_start, on_stop);";
       $('#reloadCodeButton').click(onReloadCodeButton);
       $('#loadDefaultCodeButton').click(onLoadDefaultCodeButton);
       $('#startAppButton').click(onStartAppButton);
+      $('#stopAppButton').click(onStopAppButton);
 
       loadTargetAppCode(function (responseCode, responseText) {
         if (responseCode == 200) {
@@ -235,6 +248,10 @@ ant.runtime.setCurrentApp(on_initialize, on_start, on_stop);";
         <button type="button" id="startAppButton"
           class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
           Start App
+        </button>
+        <button type="button" id="stopAppButton"
+          class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
+          Stop App
         </button>
         <h4 id="statusLabel">
           Ready

--- a/lite/app-runtime/app-editor/index.html
+++ b/lite/app-runtime/app-editor/index.html
@@ -121,6 +121,18 @@
       });
     }
 
+    function onStartAppButton() {
+      console.log("onStartAppButton");
+      var url = "http://" + getTargetUrl() + "/runtime/currentApp/command";
+      sendHTTPRequest(url, "POST", "start", function (responseCode, responseText) {
+        if (responseCode == 200) {
+          changeStatusLabel("Start app success");
+        } else {
+          changeStatusLabel("Start app failed: " + responseText);
+        }
+      });
+    }
+
     function onReloadCodeButton() {
       console.log("onReloadCodeButton");
       loadTargetAppCode(function (responseCode, responseText) {
@@ -159,6 +171,7 @@ ant.runtime.setCurrentApp(on_initialize, on_start, on_stop);";
       $('#removeAppButton').click(onRemoveAppButton);
       $('#reloadCodeButton').click(onReloadCodeButton);
       $('#loadDefaultCodeButton').click(onLoadDefaultCodeButton);
+      $('#startAppButton').click(onStartAppButton);
 
       loadTargetAppCode(function (responseCode, responseText) {
         if (responseCode == 200) {
@@ -218,6 +231,10 @@ ant.runtime.setCurrentApp(on_initialize, on_start, on_stop);";
         <button type="button" id="loadDefaultCodeButton"
           class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
           Load Default Code
+        </button>
+        <button type="button" id="startAppButton"
+          class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
+          Start App
         </button>
         <h4 id="statusLabel">
           Ready


### PR DESCRIPTION
# Summary
Add start/stop app button to app editor (Issue #155)

## Major Changes
* Add start app button to app editor
* Add stop app button to app editor

## Minor Changes

# Details
![760622B7-43A6-410C-BCB2-AA3D5C9795EB](https://user-images.githubusercontent.com/1433126/69636538-2af61600-109a-11ea-89ef-3bd08c4889c3.png)

# Test Result
Tested on Raspberry Pi 3 with both node.js and IoT.js backend